### PR TITLE
アラーム時刻までのカウントダウンをやめて現在日時との比較にする

### DIFF
--- a/WeatherAlarm/Controller/AlarmStandbyViewController.swift
+++ b/WeatherAlarm/Controller/AlarmStandbyViewController.swift
@@ -81,6 +81,7 @@ class AlarmStandbyViewController: UIViewController {
         geoCoordinatesInfo = ["lat" : latitude!, "lon" : longitude!, "appid" : APP_ID]
         getWeatherData(url: WEATHER_URL, geoCoordinatesInfo: geoCoordinatesInfo!)
         
+        // TODO: rainyAlarmTime, sunnyAlarmTime は日付が前日や翌々日だったり、秒数を持っていたりするので、時間と分数だけ比較して判断する
         if(now >= alarm!.rainyAlarmTime) {
             switch(currentLocationWeather) {
             case "clear sky", "few clouds", "scattered clouds":

--- a/WeatherAlarm/Controller/AlarmStandbyViewController.swift
+++ b/WeatherAlarm/Controller/AlarmStandbyViewController.swift
@@ -68,15 +68,11 @@ class AlarmStandbyViewController: UIViewController {
         self.remainForSunnyAlarm = self.secondsForSunnyAlarm
         self.remainForRainyAlarm = self.secondsForRainyAlarm
         
-        print("Target - rainyAlarmTime: \(alarm!.rainyAlarmTime)")
-        print("Target - sunnyAlarmTime: \(alarm!.sunnyAlarmTime)")
-        
         timer = Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(observeAlarmTimer), userInfo: nil, repeats: true)
     }
     
     @objc private func observeAlarmTimer() {
         let now = Date();
-        print("now: \(now)");
         
         let isTimeRainyAlarm = areEqualHourMinute(date1: now, date2: alarm!.rainyAlarmTime)
         let isTimeSunnyAlarm = areEqualHourMinute(date1: now, date2: alarm!.sunnyAlarmTime)


### PR DESCRIPTION
## Description
- カウントダウン方式では、アプリが background にされている間カウントが止まってしまい
アラーム時刻がズレてしまいます
- background にされる時・復帰した時に差分計算するのはたぶん面倒
- ということで現在日時比較方式にしました

## Point
- DateTimePicker は秒数も持っている & スクロールする方向や回数によっては前日や翌々日の日付が設定されるので、 `HH:mm` の部分のみ比較します
- ネスト深すぎ問題をちょっとだけマシにしました

## Test
- [x] WeatherAlarm をバックグラウンドにしてから復帰させても、アラームが鳴る時刻がズレないこと
- [x] 日付や秒数に左右されずにアラームが鳴ること
コンソール
```
2019-02-11 17:36:22.225152+0900 WeatherAlarm[5074:253686] Alarm successfully saved.
Target - rainyAlarmTime: 2019-02-10 08:40:37 +0000  // DateTimePicker で前日が選ばれちゃったよ
Target - sunnyAlarmTime: 2019-02-11 08:38:37 +0000
latitude: 37.785834, longitude: -122.406417
now: 2019-02-11 08:36:23 +0000
now: 2019-02-11 08:36:24 +0000
　（省略）
now: 2019-02-11 08:36:28 +0000
now: 2019-02-11 08:36:46 +0000  // ここで18秒バックグラウンドにしたよ
now: 2019-02-11 08:36:47 +0000
　（省略）
now: 2019-02-11 08:37:59 +0000
now: 2019-02-11 08:38:00 +0000
I need your current weather condition!  // 時間ぴったりに鳴ったよ
Success! Got the weather data
```