### PR TITLE
sunny,rainyどちらかは鳴るようにする & 画面遷移したらtimerを破棄する

### DIFF
--- a/WeatherAlarm/Controller/AlarmStandbyViewController.swift
+++ b/WeatherAlarm/Controller/AlarmStandbyViewController.swift
@@ -54,6 +54,12 @@ class AlarmStandbyViewController: UIViewController {
         timer = Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(observeAlarmTimer), userInfo: nil, repeats: true)
     }
     
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        // 別画面に遷移する時にはtimerを破棄しておく
+        timer?.invalidate()
+    }
+    
     @objc private func observeAlarmTimer() {
         print("timer ticked: \(Date())")
         
@@ -84,11 +90,19 @@ class AlarmStandbyViewController: UIViewController {
         let weatherCondition = WeatherUseCase.getWeatherCondition(weatherId: weather.id!)
         
         if isRainyAlarmRingTime {
-            AlarmUseCase.ringAlarm(alarm: rainyAlarm!, currentWeather: weatherCondition, targetWeather: Weather.Condition.rainy) ?
-                print("'Rainy' alarmed.") : print("'Rainy' misfired.")
+            if sunnyAlarm?.status == Alarm.Status.misfired {
+                AlarmUseCase.ringAlarmAnyway(alarm: rainyAlarm!)
+            } else {
+                AlarmUseCase.ringAlarm(alarm: rainyAlarm!, currentWeather: weatherCondition, targetWeather: Weather.Condition.rainy) ?
+                    print("'Rainy' alarmed.") : print("'Rainy' misfired.")
+            }
         } else if isSunnyAlarmRingTime {
-            AlarmUseCase.ringAlarm(alarm: sunnyAlarm!, currentWeather: weatherCondition, targetWeather: Weather.Condition.sunny) ?
-                print("'Sunny' alarmed.") : print("'Sunny' misfired.")
+            if rainyAlarm?.status == Alarm.Status.misfired {
+                AlarmUseCase.ringAlarmAnyway(alarm: sunnyAlarm!)
+            } else {
+                AlarmUseCase.ringAlarm(alarm: sunnyAlarm!, currentWeather: weatherCondition, targetWeather: Weather.Condition.sunny) ?
+                    print("'Sunny' alarmed.") : print("'Sunny' misfired.")
+            }
         }
     }
     

--- a/WeatherAlarm/Controller/AlarmStandbyViewController.swift
+++ b/WeatherAlarm/Controller/AlarmStandbyViewController.swift
@@ -91,14 +91,16 @@ class AlarmStandbyViewController: UIViewController {
         
         if isRainyAlarmRingTime {
             if sunnyAlarm?.status == Alarm.Status.misfired {
-                AlarmUseCase.ringAlarmAnyway(alarm: rainyAlarm!)
+                AlarmUseCase.ringAlarmForcibly(alarm: rainyAlarm!)
+                print("'Rainy' alarmed forcibly.")
             } else {
                 AlarmUseCase.ringAlarm(alarm: rainyAlarm!, currentWeather: weatherCondition, targetWeather: Weather.Condition.rainy) ?
                     print("'Rainy' alarmed.") : print("'Rainy' misfired.")
             }
         } else if isSunnyAlarmRingTime {
             if rainyAlarm?.status == Alarm.Status.misfired {
-                AlarmUseCase.ringAlarmAnyway(alarm: sunnyAlarm!)
+                AlarmUseCase.ringAlarmForcibly(alarm: sunnyAlarm!)
+                print("'Sunny' alarmed forcibly.")
             } else {
                 AlarmUseCase.ringAlarm(alarm: sunnyAlarm!, currentWeather: weatherCondition, targetWeather: Weather.Condition.sunny) ?
                     print("'Sunny' alarmed.") : print("'Sunny' misfired.")

--- a/WeatherAlarm/UseCase/AlarmUseCase.swift
+++ b/WeatherAlarm/UseCase/AlarmUseCase.swift
@@ -68,4 +68,9 @@ class AlarmUseCase {
         alarm.status = Alarm.Status.rang
         return true
     }
+    
+    static func ringAlarmAnyway(alarm: Alarm){
+        alarm.sound?.play()
+        alarm.status = Alarm.Status.rang
+    }
 }

--- a/WeatherAlarm/UseCase/AlarmUseCase.swift
+++ b/WeatherAlarm/UseCase/AlarmUseCase.swift
@@ -69,7 +69,7 @@ class AlarmUseCase {
         return true
     }
     
-    static func ringAlarmAnyway(alarm: Alarm){
+    static func ringAlarmForcibly(alarm: Alarm){
         alarm.sound?.play()
         alarm.status = Alarm.Status.rang
     }


### PR DESCRIPTION
## Description
#### sunny, rainy どちらかのアラームを鳴らす対応
- 現状、例えばrainyの時間が先に来て、そのときはsunnyの条件だったものの、
その後sunnyの時間が来るまでに天気が変わってrainyの条件になってしまった場合、
どちらも鳴らずに終わる可能性がありました
- 先に時間がきたほうが鳴らされなかった(misfired)場合、
後に時間がきたほうは天気関係なく鳴らすようにしました

#### 画面遷移したらtimerを破棄するようにした
- スタンバイ画面からBackしても `timer ticked:` が出続けてやがったので修正

## Test
- [x] 先に時間がきたアラームが不発だったとき、後から時間がきたほうが天気に関係なく鳴らされること。
  - ※ sunnyが鳴る天気情報が取得されるとき、sunnyを常にmisfiredにするコードを仕込んで、sunnyの時間が先にくる設定にして動作させて確認
  - ※ UTほしい
```
timer ticked: 2019-04-07 08:08:00 +0000
{
  ...
  "weather" : [
    {
      "id" : 701, // 700番台はsunny条件だよ
      "icon" : "50n",
      "description" : "mist",
      "main" : "Mist"
    }
  ],
  ...
}
'Rainy' alarmed forcibly. // Rainyの条件じゃないがアラームを鳴らしたよ
```
- [x] スタンバイ画面からBackしたら、`timer ticked:` が出なくなること