### PR TITLE
天気情報が取得できなければ、時間がきたアラームを強制的に鳴らすようにした

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -14,5 +14,6 @@ target 'WeatherAlarm' do
   
   pod 'SwiftyJSON', '4.2.0'
   pod 'Alamofire', '4.7.3'
+  pod 'ReachabilitySwift', '4.3.0'
 
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,20 +1,24 @@
 PODS:
   - Alamofire (4.7.3)
+  - ReachabilitySwift (4.3.0)
   - SwiftyJSON (4.2.0)
 
 DEPENDENCIES:
   - Alamofire (= 4.7.3)
+  - ReachabilitySwift (= 4.3.0)
   - SwiftyJSON (= 4.2.0)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
     - Alamofire
+    - ReachabilitySwift
     - SwiftyJSON
 
 SPEC CHECKSUMS:
   Alamofire: c7287b6e5d7da964a70935e5db17046b7fde6568
+  ReachabilitySwift: 408477d1b6ed9779dba301953171e017c31241f3
   SwiftyJSON: c4bcba26dd9ec7a027fc8eade48e2c911f229e96
 
-PODFILE CHECKSUM: 40804cade0e8fd3c6d6d759d6b50bd77ac1cf3aa
+PODFILE CHECKSUM: 31fac2e0778f93456a7e3689e08f40cbbe74d2f3
 
 COCOAPODS: 1.5.3

--- a/WeatherAlarm.xcodeproj/project.pbxproj
+++ b/WeatherAlarm.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		5C71ED7F222AB190002CD717 /* Alarm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C71ED7E222AB190002CD717 /* Alarm.swift */; };
 		5C71ED84222ACC97002CD717 /* AlarmUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C71ED83222ACC97002CD717 /* AlarmUseCase.swift */; };
+		5C85DDB5226337AB00A90CAF /* NetworkChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C85DDB4226337AB00A90CAF /* NetworkChecker.swift */; };
 		5CAE5C8B222BDD65009EE0FB /* AlarmRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CAE5C8A222BDD65009EE0FB /* AlarmRepository.swift */; };
 		5CE966452231633700263A2D /* Weather.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE966442231633700263A2D /* Weather.swift */; };
 		5CE966482231643000263A2D /* WeatherApiClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE966472231643000263A2D /* WeatherApiClient.swift */; };
@@ -44,6 +45,7 @@
 		42FA32884084C6145561B182 /* Pods_WeatherAlarm.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WeatherAlarm.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5C71ED7E222AB190002CD717 /* Alarm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Alarm.swift; sourceTree = "<group>"; };
 		5C71ED83222ACC97002CD717 /* AlarmUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmUseCase.swift; sourceTree = "<group>"; };
+		5C85DDB4226337AB00A90CAF /* NetworkChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkChecker.swift; sourceTree = "<group>"; };
 		5CAE5C8A222BDD65009EE0FB /* AlarmRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmRepository.swift; sourceTree = "<group>"; };
 		5CE966442231633700263A2D /* Weather.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Weather.swift; sourceTree = "<group>"; };
 		5CE966472231643000263A2D /* WeatherApiClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherApiClient.swift; sourceTree = "<group>"; };
@@ -148,6 +150,7 @@
 			isa = PBXGroup;
 			children = (
 				5CE966472231643000263A2D /* WeatherApiClient.swift */,
+				5C85DDB4226337AB00A90CAF /* NetworkChecker.swift */,
 			);
 			path = DataAccessor;
 			sourceTree = "<group>";
@@ -403,6 +406,7 @@
 			files = (
 				5CE9664C2231663B00263A2D /* GeoLocation.swift in Sources */,
 				CCE7DBCC21EB555D00D1415F /* CLLocationManagerDelegate.swift in Sources */,
+				5C85DDB5226337AB00A90CAF /* NetworkChecker.swift in Sources */,
 				CCD8F966217B69BC00C4B00F /* AlarmViewController.swift in Sources */,
 				5C71ED84222ACC97002CD717 /* AlarmUseCase.swift in Sources */,
 				5CE966482231643000263A2D /* WeatherApiClient.swift in Sources */,

--- a/WeatherAlarm.xcodeproj/project.pbxproj
+++ b/WeatherAlarm.xcodeproj/project.pbxproj
@@ -348,6 +348,7 @@
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-WeatherAlarm/Pods-WeatherAlarm-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
+				"${BUILT_PRODUCTS_DIR}/ReachabilitySwift/Reachability.framework",
 				"${BUILT_PRODUCTS_DIR}/SwiftyJSON/SwiftyJSON.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -355,6 +356,7 @@
 			);
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Reachability.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftyJSON.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WeatherAlarm/Controller/AlarmStandbyViewController.swift
+++ b/WeatherAlarm/Controller/AlarmStandbyViewController.swift
@@ -83,7 +83,7 @@ class AlarmStandbyViewController: UIViewController {
         geoLocation.longitude = longitude
 
         let weather = weatherApiClient.getWeather(geoLocation: geoLocation)
-        let weatherCondition = WeatherUseCase.getWeatherCondition(weatherId: weather.id!)
+        let weatherCondition = WeatherUseCase.getWeatherCondition(weatherId: weather.id)
         
         if isRainyAlarmRingTime {
             if weatherCondition == Weather.Condition.unsure || sunnyAlarm?.status == Alarm.Status.misfired {

--- a/WeatherAlarm/Controller/AlarmStandbyViewController.swift
+++ b/WeatherAlarm/Controller/AlarmStandbyViewController.swift
@@ -83,14 +83,10 @@ class AlarmStandbyViewController: UIViewController {
         geoLocation.longitude = longitude
 
         let weather = weatherApiClient.getWeather(geoLocation: geoLocation)
-        if weather.id == nil {
-            return
-        }
-        
         let weatherCondition = WeatherUseCase.getWeatherCondition(weatherId: weather.id!)
         
         if isRainyAlarmRingTime {
-            if sunnyAlarm?.status == Alarm.Status.misfired {
+            if weatherCondition == Weather.Condition.unsure || sunnyAlarm?.status == Alarm.Status.misfired {
                 AlarmUseCase.ringAlarmForcibly(alarm: rainyAlarm!)
                 print("'Rainy' alarmed forcibly.")
             } else {
@@ -100,7 +96,7 @@ class AlarmStandbyViewController: UIViewController {
         }
         
         if isSunnyAlarmRingTime {
-            if rainyAlarm?.status == Alarm.Status.misfired {
+            if weatherCondition == Weather.Condition.unsure || rainyAlarm?.status == Alarm.Status.misfired {
                 AlarmUseCase.ringAlarmForcibly(alarm: sunnyAlarm!)
                 print("'Sunny' alarmed forcibly.")
             } else {

--- a/WeatherAlarm/Controller/AlarmStandbyViewController.swift
+++ b/WeatherAlarm/Controller/AlarmStandbyViewController.swift
@@ -82,9 +82,13 @@ class AlarmStandbyViewController: UIViewController {
         geoLocation.latitude = latitude
         geoLocation.longitude = longitude
 
-        let weather = weatherApiClient.getWeather(geoLocation: geoLocation)
-        let weatherCondition = WeatherUseCase.getWeatherCondition(weatherId: weather.id)
-        
+        var weatherCondition = Weather.Condition.unsure
+        // 通信可能な場合のみ天気情報を取得する。ネット未接続なら時間が来たアラームを鳴らす。
+        if NetworkChecker.reachable() {
+            let weather = self.weatherApiClient.getWeather(geoLocation: geoLocation)
+            weatherCondition = WeatherUseCase.getWeatherCondition(weatherId: weather.id)
+        }
+
         if isRainyAlarmRingTime {
             if weatherCondition == Weather.Condition.unsure || sunnyAlarm?.status == Alarm.Status.misfired {
                 AlarmUseCase.ringAlarmForcibly(alarm: rainyAlarm!)

--- a/WeatherAlarm/DataAccessor/NetworkChecker.swift
+++ b/WeatherAlarm/DataAccessor/NetworkChecker.swift
@@ -1,0 +1,19 @@
+//
+//  NetworkChecker.swift
+//  WeatherAlarm
+//
+//  Created by Kunihisa Fujiwara on 2019/04/14.
+//  Copyright © 2019 金子宏樹. All rights reserved.
+//
+
+import Reachability
+
+class NetworkChecker {
+    static func reachable() -> Bool {
+        if let reachability = Reachability() {
+            print("Reachability.connection : \(reachability.connection)")
+            return reachability.connection != .none
+        }
+        return false
+    }
+}

--- a/WeatherAlarm/DataAccessor/WeatherApiClient.swift
+++ b/WeatherAlarm/DataAccessor/WeatherApiClient.swift
@@ -34,8 +34,13 @@ class WeatherApiClient: NSObject {
                 let responseJson: JSON = JSON(response.result.value!)
                 print(responseJson)
                 
-                weather.id = responseJson["weather"][0]["id"].stringValue
-                weather.description = responseJson["weather"][0]["description"].stringValue
+                if responseJson["cod"] == 200 {
+                    weather.id = responseJson["weather"][0]["id"].stringValue
+                    weather.description = responseJson["weather"][0]["description"].stringValue
+                } else {
+                    // WeatherAPI にアクセスできたものの、正常応答が得られなかった場合
+                    print("Response condition is not 200: \(responseJson["cod"])")
+                }
             } else {
                 print("Error \(String(describing: response.result.error))")
             }

--- a/WeatherAlarm/Entity/Weather.swift
+++ b/WeatherAlarm/Entity/Weather.swift
@@ -12,5 +12,6 @@ class Weather {
     enum Condition: String, CaseIterable {
         case sunny
         case rainy
+        case unsure
     }
 }

--- a/WeatherAlarm/UseCase/WeatherUseCase.swift
+++ b/WeatherAlarm/UseCase/WeatherUseCase.swift
@@ -7,14 +7,18 @@
 //
 
 class WeatherUseCase {
-    static func getWeatherCondition(weatherId: String) -> Weather.Condition {
+    static func getWeatherCondition(weatherId: String?) -> Weather.Condition {
+        if weatherId == nil {
+            return Weather.Condition.unsure
+        }
+        
         // id 2xx, 3xx, 4xx, 5xx and 6xx are 'Rainy'
         // https://openweathermap.org/weather-conditions
-        if weatherId.hasPrefix("2") ||
-            weatherId.hasPrefix("3") ||
-            weatherId.hasPrefix("4") ||
-            weatherId.hasPrefix("5") ||
-            weatherId.hasPrefix("6") {
+        if weatherId!.hasPrefix("2") ||
+            weatherId!.hasPrefix("3") ||
+            weatherId!.hasPrefix("4") ||
+            weatherId!.hasPrefix("5") ||
+            weatherId!.hasPrefix("6") {
             return Weather.Condition.rainy
         }
         // otherwise 'Sunny'


### PR DESCRIPTION
## Description
以下のケースの対応です
- ネット接続できない
- ネット接続できWeatherAPIも叩けたが、結果異常だった

この場合は天気によらず時間のきたアラームを鳴らすものとします。

## Test
- [x] Wifi未接続でアラームが鳴る
- [x] appIdを適当に書き換えてWeatherAPIが401を返してもアラームが鳴る
- [x] 正常時には今まで通り天気に応じてアラームが鳴る