### PR TITLE
[arch] Snooze設定の読み込み・保存・切り替えをUseCase化

### DIFF
--- a/WeatherAlarm.xcodeproj/project.pbxproj
+++ b/WeatherAlarm.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		2A874071228AC9A200C4F49D /* ConfigUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A874070228AC9A200C4F49D /* ConfigUseCase.swift */; };
 		2A874073228AC9DC00C4F49D /* LocationAgreementViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A874072228AC9DC00C4F49D /* LocationAgreementViewController.swift */; };
 		2A874075228AC9FC00C4F49D /* LocationRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A874074228AC9FC00C4F49D /* LocationRepository.swift */; };
 		2A874077228ACA1D00C4F49D /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A874076228ACA1D00C4F49D /* Config.swift */; };
@@ -15,6 +14,7 @@
 		5C51872222C2D94F007D2B44 /* AlarmRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C51872122C2D94F007D2B44 /* AlarmRepositoryProtocol.swift */; };
 		5C51872422C2DC6E007D2B44 /* CacheDataAccessorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C51872322C2DC6E007D2B44 /* CacheDataAccessorProtocol.swift */; };
 		5C51872622C2DD86007D2B44 /* CacheDataAccessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C51872522C2DD86007D2B44 /* CacheDataAccessor.swift */; };
+		5C51872822C3BBFA007D2B44 /* ConfigRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C51872722C3BBF9007D2B44 /* ConfigRepositoryProtocol.swift */; };
 		5C71ED7F222AB190002CD717 /* Alarm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C71ED7E222AB190002CD717 /* Alarm.swift */; };
 		5C71ED84222ACC97002CD717 /* AlarmUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C71ED83222ACC97002CD717 /* AlarmUseCase.swift */; };
 		5C85DDB5226337AB00A90CAF /* NetworkChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C85DDB4226337AB00A90CAF /* NetworkChecker.swift */; };
@@ -51,7 +51,6 @@
 /* Begin PBXFileReference section */
 		0776B1E629A069F246DFD845 /* Pods-WeatherAlarm.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WeatherAlarm.debug.xcconfig"; path = "Pods/Target Support Files/Pods-WeatherAlarm/Pods-WeatherAlarm.debug.xcconfig"; sourceTree = "<group>"; };
 		0CD4F052C81BDE8DAAD9A48A /* Pods-WeatherAlarmTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WeatherAlarmTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-WeatherAlarmTests/Pods-WeatherAlarmTests.debug.xcconfig"; sourceTree = "<group>"; };
-		2A874070228AC9A200C4F49D /* ConfigUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ConfigUseCase.swift; path = WeatherAlarm/UseCase/ConfigUseCase.swift; sourceTree = SOURCE_ROOT; };
 		2A874072228AC9DC00C4F49D /* LocationAgreementViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = LocationAgreementViewController.swift; path = WeatherAlarm/Controller/LocationAgreementViewController.swift; sourceTree = SOURCE_ROOT; };
 		2A874074228AC9FC00C4F49D /* LocationRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LocationRepository.swift; path = WeatherAlarm/Repository/LocationRepository.swift; sourceTree = SOURCE_ROOT; };
 		2A874076228ACA1D00C4F49D /* Config.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Config.swift; path = WeatherAlarm/Entity/Config.swift; sourceTree = SOURCE_ROOT; };
@@ -61,6 +60,7 @@
 		5C51872122C2D94F007D2B44 /* AlarmRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmRepositoryProtocol.swift; sourceTree = "<group>"; };
 		5C51872322C2DC6E007D2B44 /* CacheDataAccessorProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheDataAccessorProtocol.swift; sourceTree = "<group>"; };
 		5C51872522C2DD86007D2B44 /* CacheDataAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheDataAccessor.swift; sourceTree = "<group>"; };
+		5C51872722C3BBF9007D2B44 /* ConfigRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigRepositoryProtocol.swift; sourceTree = "<group>"; };
 		5C71ED7E222AB190002CD717 /* Alarm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Alarm.swift; sourceTree = "<group>"; };
 		5C71ED83222ACC97002CD717 /* AlarmUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmUseCase.swift; sourceTree = "<group>"; };
 		5C85DDB4226337AB00A90CAF /* NetworkChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkChecker.swift; sourceTree = "<group>"; };
@@ -147,6 +147,7 @@
 				5C51871F22C2D912007D2B44 /* SetAlarmUseCase.swift */,
 				5C51872122C2D94F007D2B44 /* AlarmRepositoryProtocol.swift */,
 				5C51872322C2DC6E007D2B44 /* CacheDataAccessorProtocol.swift */,
+				5C51872722C3BBF9007D2B44 /* ConfigRepositoryProtocol.swift */,
 			);
 			path = Alarm;
 			sourceTree = "<group>";
@@ -167,7 +168,6 @@
 			children = (
 				5C51871E22C2D8EC007D2B44 /* Alarm */,
 				5C71ED83222ACC97002CD717 /* AlarmUseCase.swift */,
-				2A874070228AC9A200C4F49D /* ConfigUseCase.swift */,
 				5CE966492231644900263A2D /* WeatherUseCase.swift */,
 			);
 			path = UseCase;
@@ -445,6 +445,7 @@
 				5CE9664C2231663B00263A2D /* GeoLocation.swift in Sources */,
 				2A874073228AC9DC00C4F49D /* LocationAgreementViewController.swift in Sources */,
 				5C85DDB5226337AB00A90CAF /* NetworkChecker.swift in Sources */,
+				5C51872822C3BBFA007D2B44 /* ConfigRepositoryProtocol.swift in Sources */,
 				2A874077228ACA1D00C4F49D /* Config.swift in Sources */,
 				CCD8F966217B69BC00C4B00F /* AlarmViewController.swift in Sources */,
 				B1096A2822BF6DD400229B7D /* SoundTableViewCell.swift in Sources */,
@@ -460,7 +461,6 @@
 				CCBC344F211F495600BF6E6D /* AppDelegate.swift in Sources */,
 				5C51872222C2D94F007D2B44 /* AlarmRepositoryProtocol.swift in Sources */,
 				2A874075228AC9FC00C4F49D /* LocationRepository.swift in Sources */,
-				2A874071228AC9A200C4F49D /* ConfigUseCase.swift in Sources */,
 				5C51872422C2DC6E007D2B44 /* CacheDataAccessorProtocol.swift in Sources */,
 				5C71ED7F222AB190002CD717 /* Alarm.swift in Sources */,
 				5CE966452231633700263A2D /* Weather.swift in Sources */,

--- a/WeatherAlarm/Controller/AlarmStandbyViewController.swift
+++ b/WeatherAlarm/Controller/AlarmStandbyViewController.swift
@@ -156,7 +156,7 @@ class AlarmStandbyViewController: UIViewController, LocationRepositoryDelegate {
             alarmingLocation.text = weatherCondition == Weather.Condition.unsure ? "" : weather.place!
             
             //スヌーズONの場合はもう一度カウント
-            if(configRepository.getSnoozeOn()) {
+            if(configRepository.getConfig().isSnoozeOn) {
                 self.snoozeAlarmButton.isHidden = false
                 self.snoozeAlarmButton.isEnabled = true
                 self.snoozeAlarmButton.setTitle("SNOOZE", for: .normal)

--- a/WeatherAlarm/Controller/AlarmViewController.swift
+++ b/WeatherAlarm/Controller/AlarmViewController.swift
@@ -18,10 +18,9 @@ class AlarmViewController: UIViewController {
     
     private let setAlarmUseCase: SetAlarmUseCse
         = SetAlarmUseCse(alarmRepository: AlarmRepository.sharedInstance,
+                         configRepository: ConfigRepository.sharedInstance,
                          cacheDataAccessor: CacheDataAccessor())
     
-    private let configRepository: ConfigRepository = ConfigRepository.sharedInstance
-
     @IBAction func setSunnyAlarm(_ sender: UIDatePicker) {
         setAlarmUseCase.updateAlarmTime(weather: Weather.Condition.sunny, dateTime: sender.date)
     }
@@ -31,7 +30,7 @@ class AlarmViewController: UIViewController {
     }
     
     @IBAction func changeSnoozeOnOff(_ sender: UISwitch) {
-        configRepository.setSnoozeOn(isSnoozeOn: sender.isOn)
+        setAlarmUseCase.setSnooze(isSnoozeOn: sender.isOn)
     }
     
     @IBAction func standbyAlarm(_ sender: UIButton) {

--- a/WeatherAlarm/DataAccessor/CacheDataAccessor.swift
+++ b/WeatherAlarm/DataAccessor/CacheDataAccessor.swift
@@ -9,7 +9,6 @@
 import Foundation
 
 class CacheDataAccessor: CacheDataAccessorProtocol {
-    
     func loadAlarm(weather: Weather.Condition) -> Alarm? {
         //loadできなかった場合はnilが返るようにします
         var alarm: Alarm?
@@ -27,10 +26,34 @@ class CacheDataAccessor: CacheDataAccessorProtocol {
         do {
             //alarmsを保存するためアーカイブ
             let archiveData = try NSKeyedArchiver.archivedData(withRootObject: alarm, requiringSecureCoding: true)
-            //アーカイブしたalarmsをUserDefaultsに保存
+            //アーカイブしたalarmをUserDefaultsに保存
             UserDefaults.standard.set(archiveData, forKey: weather.rawValue)
         } catch {
             print(error)
         }
     }
+    
+    func loadConfig() -> Config? {
+        var config: Config?
+        if let loadedData = UserDefaults().data(forKey: "config") {
+            do {
+                config = try NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(loadedData) as? Config
+            } catch {
+                print("Load failed")
+            }
+        }
+        return config
+    }
+    
+    func saveConfig(config: Config) {
+        do {
+            //alarmsを保存するためアーカイブ
+            let archiveData = try NSKeyedArchiver.archivedData(withRootObject: config, requiringSecureCoding: true)
+            //アーカイブしたconfigをUserDefaultsに保存
+            UserDefaults.standard.set(archiveData, forKey: "config")
+        } catch {
+            print(error)
+        }
+    }
+    
 }

--- a/WeatherAlarm/Entity/Config.swift
+++ b/WeatherAlarm/Entity/Config.swift
@@ -9,21 +9,19 @@
 import Foundation
 
 class Config: NSObject, NSSecureCoding {
-    static let sharedInstance: Config = Config()
-    
     static var supportsSecureCoding: Bool = true
     
-    var isSnoozeOn: Bool?
+    var isSnoozeOn: Bool
     
     func encode(with aCoder: NSCoder) {
         aCoder.encode(isSnoozeOn, forKey: "isSnoozeOn")
     }
     
     required init?(coder aDecoder: NSCoder) {
-        self.isSnoozeOn = (aDecoder.decodeObject(forKey: "isSnoozeOn") as? Bool)
+        self.isSnoozeOn = (aDecoder.decodeObject(forKey: "isSnoozeOn") as? Bool) ?? false
     }
     
-    private override init() {
+    override init() {
         self.isSnoozeOn = false
     }
 }

--- a/WeatherAlarm/Repository/ConfigRepository.swift
+++ b/WeatherAlarm/Repository/ConfigRepository.swift
@@ -7,35 +7,19 @@
 //
 
 import Foundation
-class ConfigRepository: NSObject, NSSecureCoding {
+class ConfigRepository: NSObject, ConfigRepositoryProtocol {
     static let sharedInstance: ConfigRepository = ConfigRepository()
-    
-    static var supportsSecureCoding: Bool = true
-    
-    private var isSnoozeOn: Bool = false
-    
-    func encode(with aCoder: NSCoder) {
-        aCoder.encode(isSnoozeOn, forKey: "isSnoozeOn")
-    }
-    
-    required init?(coder aDecoder: NSCoder) {
-        self.isSnoozeOn = (aDecoder.decodeObject(forKey: "isSnoozeOn") as! Bool)
-    }
+    private var config: Config
     
     private override init() {
-        self.isSnoozeOn = false
+        self.config = Config()
     }
     
-    func setSnoozeOn(isSnoozeOn: Bool) {
-        self.isSnoozeOn = isSnoozeOn
-        //TODO: save
+    func getConfig() -> Config {
+        return self.config
     }
     
-    func getSnoozeOn() -> Bool {
-        return self.isSnoozeOn
-    }
-    
-    func loadConfig() {
-        //TODO: load
+    func setConfig(config: Config) {
+        self.config = config
     }
 }

--- a/WeatherAlarm/UseCase/Alarm/CacheDataAccessorProtocol.swift
+++ b/WeatherAlarm/UseCase/Alarm/CacheDataAccessorProtocol.swift
@@ -11,4 +11,6 @@ import Foundation
 protocol CacheDataAccessorProtocol {
     func loadAlarm(weather: Weather.Condition) -> Alarm?
     func saveAlarm(weather: Weather.Condition, alarm: Alarm)
+    func loadConfig() -> Config?
+    func saveConfig(config: Config)
 }

--- a/WeatherAlarm/UseCase/Alarm/ConfigRepositoryProtocol.swift
+++ b/WeatherAlarm/UseCase/Alarm/ConfigRepositoryProtocol.swift
@@ -1,0 +1,14 @@
+//
+//  ConfigRepositoryProtocol.swift
+//  WeatherAlarm
+//
+//  Created by Kunihisa Fujiwara on 2019/06/26.
+//  Copyright © 2019 金子宏樹. All rights reserved.
+//
+
+import Foundation
+
+protocol ConfigRepositoryProtocol {
+    func getConfig() -> Config
+    func setConfig(config: Config)
+}

--- a/WeatherAlarm/UseCase/Alarm/SetAlarmUseCase.swift
+++ b/WeatherAlarm/UseCase/Alarm/SetAlarmUseCase.swift
@@ -10,11 +10,14 @@ import Foundation
 
 class SetAlarmUseCse {
     private var alarmRepository: AlarmRepositoryProtocol
+    private var configRepository: ConfigRepositoryProtocol
     private var cacheDataAccessor: CacheDataAccessorProtocol
     
     init(alarmRepository: AlarmRepositoryProtocol,
+         configRepository: ConfigRepositoryProtocol,
          cacheDataAccessor: CacheDataAccessorProtocol) {
         self.alarmRepository = alarmRepository
+        self.configRepository = configRepository
         self.cacheDataAccessor = cacheDataAccessor
     }
     
@@ -42,5 +45,13 @@ class SetAlarmUseCse {
         alarmRepository.setAlarm(weather: weather, alarm: alarm)
         //アラーム時刻が更新されるたびにキャッシュも更新します
         cacheDataAccessor.saveAlarm(weather: weather, alarm: alarm)
+    }
+    
+    func setSnooze(isSnoozeOn: Bool) {
+        let config = configRepository.getConfig()
+        config.isSnoozeOn = isSnoozeOn
+        configRepository.setConfig(config: config)
+        //snooze設定が切り替えられるたびにキャッシュも更新します
+        cacheDataAccessor.saveConfig(config: config)
     }
 }


### PR DESCRIPTION
- Config と ConfigRepository 両方が NSCoding を実装していたが、
UserDefaultsに保存するうえでは Config のみ実装していればOK
- ConfigUseCase はもともと大した処理していなかったし SetAlarmUseCase により不要になったので削除